### PR TITLE
Modified the NEMS connectivity targets according to the domain changes.

### DIFF
--- a/docs/Guidelines/Publisher/index.md
+++ b/docs/Guidelines/Publisher/index.md
@@ -64,10 +64,10 @@ The table below provides the network details of NEMS production and test environ
 
 |**Source**|**Target**|**Port**|**Comments**|
 | :- | :- | :- | :- |
-|Publisher application|nems.services.health.nz|55443|TCPS, SMF protocols|
-|Publisher test application|nems-test.services.health.nz|55443|TCPS, SMF protocols|
-|Publisher application|nems.services.health.nz|9443|HTTPS, REST endpoint|
-|Publisher test application|nems-test.services.health.nz|9443|HTTPS, REST endpoint|
+|Publisher application|api.nems.digital.health.nz|55443|TCPS, SMF protocols|
+|Publisher test application|api.test.nems.digital.health.nz|55443|TCPS, SMF protocols|
+|Publisher application|api.nems.digital.health.nz|9443|HTTPS, REST endpoint|
+|Publisher test application|api.test.nems.digital.health.nz|9443|HTTPS, REST endpoint|
 
 ## Publishing patterns
 
@@ -164,4 +164,4 @@ It is also important that the publisher can recover from failure to reduce the r
 
 ##Traceability and Audit
 
-The publisher should at least recording the `messageId`, `messageSubjectId` and `publishing timestamp` in your logs (or traces) to satisfy the end to end traceability requirements.
+The publisher should at least record the `messageId`, `messageSubjectId` and `publishing timestamp` in your logs (or traces) to satisfy the end to end traceability requirements.

--- a/docs/Guidelines/Subscriber/index.md
+++ b/docs/Guidelines/Subscriber/index.md
@@ -69,8 +69,8 @@ We recommend and assume that you deploy your subscriber application behind a fir
 
 |**Source**|**Target**|**Port**|**Comments**|
 | :- | :- | :- | :- |
-|nems.services.health.nz|Subscriber production|55443|JMS, SMF protocols|
-|nems-test.services.health.nz|Subscriber non-production|55443|JMS, SMF protocols|
+|api.nems.digital.health.nz|Subscriber production|55443|JMS, SMF protocols|
+|api.test.nems.digital.health.nz|Subscriber non-production|55443|JMS, SMF protocols|
 
 NEMS is configured for maximum availability. It is deployed in a high-availability configuration with a disaster recovery in a remote data centre. Maintenance can occur on the brokers from time-to-time. Maintenance procedures will be applied in a rolling fashion. It is important that subscribers implement retry functionality if they don’t want to be disconnected during maintenance procedures. Given the connection mandates OAuth 2.0, the client application should reconnect when a node is switched. This should happen instantaneously, however during a disaster the outage could be prolonged as there are some manual steps put in place to confirm that the switch of data centres is justified. Availability will adhere to the service level agreement of the platform.
 

--- a/docs/Technical-Instructions/Publisher/index.md
+++ b/docs/Technical-Instructions/Publisher/index.md
@@ -24,10 +24,10 @@ The NEMS event broker is publicly available and requires an internet connection 
 
 |**Protocol**|**Source**|**Target**|**Connection**|
 | :-: | :- | :- | :- |
-|Native|NEMS production environment |nems.services.health.nz|TCP 55443|
-|Native|NEMS test environment|nems-test.services.health.nz|TCP 55443|
-|REST|NEMS production environment|nems.services.health.nz|HTTP 9443|
-|REST|NEMS test environment|nems-test.services.health.nz|HTTP 9443|
+|Native|NEMS production environment |api.nems.digital.health.nz|TCP 55443|
+|Native|NEMS test environment|api.test.nems.digital.health.nz|TCP 55443|
+|REST|NEMS production environment|api.nems.digital.health.nz|HTTP 9443|
+|REST|NEMS test environment|api.test.nems.digital.health.nz|HTTP 9443|
 
 ## Connect and authenticate
 

--- a/docs/Technical-Instructions/Subscriber/index.md
+++ b/docs/Technical-Instructions/Subscriber/index.md
@@ -41,8 +41,8 @@ The NEMS event broker is publicly available and requires outbound ports to be ac
 
 |**Source**|**Target**|**Port**|
 | :- | :- | :- |
-|NEMS standard production environment for subscribers|nems.services.health.nz|TCP 55443|
-|NEMS standard test environment for subscribers|nems-test.services.health.nz|TCP 55443|
+|NEMS standard production environment for subscribers|api.nems.digital.health.nz|TCP 55443|
+|NEMS standard test environment for subscribers|api.test.nems.digital.health.nz|TCP 55443|
 
 ## Connect and authenticate
 


### PR DESCRIPTION
Domain name changes:
`nems.services.health.nz` -> `api.nems.digital.health.nz`
`nems-test.services.health.nz` -> `api.test.nems.digital.health.nz`